### PR TITLE
Typo fix

### DIFF
--- a/docs/config/uploader.md
+++ b/docs/config/uploader.md
@@ -2,7 +2,7 @@
 This page documents the uploader configuration of Zipline.
 
 ## `UPLOADER_DEFAULT_FORMAT`
-The default 'upload format' for files. For more info on what values are accepted, see [here][(/docs/guides/upload-options#image-format).
+The default 'upload format' for files. For more info on what values are accepted, see [here](/docs/guides/upload-options#image-format).
 ```bash
 UPLOADER_DEFAULT_FORMAT=NAME
 ```


### PR DESCRIPTION
Link under UPLOADER_DEFAULT_FORMAT section is currently broken due to an extraneous `[`