### PR TITLE
Responsive fixes for mobile 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zipline-docs",
-  "version": "3.7.0",
+  "version": "3.7.3",
   "private": true,
   "scripts": {
     "dev": "node --experimental-fetch scripts/runAll.mjs && next dev",


### PR DESCRIPTION
The v3-latest branch was recreated with trunk as the source as it seemed to get out of sync, making it require a bunch of older commits that have already been committed to be recommitted. This pr will just inhibit a deployment for vercel.