### PR TITLE
chore: typo in docker link

### DIFF
--- a/docs/get-started/docker.mdx
+++ b/docs/get-started/docker.mdx
@@ -6,10 +6,10 @@ sidebar_position: 1
 
 ## Install & run with Docker Compose
 
-First, download the `docker-compose.yml` file using `curl` or `wget` with the following command:
+First, download the `docker-compose.yml` file using `wget` or `curl` with the following command:
 
 ```bash
-curl -O https://zipline.diced.sh/api/docker-compose.yml
+wget https://v4.zipline.diced.sh/api/docker-compose.yml
 ```
 
 If you don't already have a `.env` file with a database password and zipline secret, you can generate one with the following command:


### PR DESCRIPTION
missed the v4 in the link. Small fix