### PR TITLE
Fix date and time formatting examples in variables guide

### DIFF
--- a/docs/guides/variables.mdx
+++ b/docs/guides/variables.mdx
@@ -138,8 +138,8 @@ unknown -> `{unknown_int_modifier({mod})}`
 | Modifier | Description                                              | Example                                   |                                                            |
 | -------- | -------------------------------------------------------- | ----------------------------------------- | ---------------------------------------------------------- |
 | `locale` | Format the date to the locale provided or system default | `9/22/2024` -> `9/22/2024, 12:00:00 AM`   | [locale/timezone configuration](#localetimezone-modifiers) |
-| `time`   | Format the date to the time provided                     | `9/22/2024` -> `9/22/2024`                | [locale/timezone configuration](#localetimezone-modifiers) |
-| `date`   | Format the date to the date provided                     | `9/22/2024` -> `12:00:00 AM`              | [locale/timezone configuration](#localetimezone-modifiers) |
+| `time`   | Format the date to the time provided                     | `9/22/2024` -> `12:00:00 AM`              | [locale/timezone configuration](#localetimezone-modifiers) |
+| `date`   | Format the date to the date provided                     | `9/22/2024` -> `9/22/2024`                | [locale/timezone configuration](#localetimezone-modifiers) |
 | `unix`   | Convert the date to a Unix timestamp                     | `9/22/2024` -> `1692819200000`            |
 | `iso`    | Convert the date to an ISO string                        | `9/22/2024` -> `2024-09-22T00:00:00.000Z` |
 | `utc`    | Convert the date to UTC time                             | `9/22/2024` -> `2024-09-22T00:00:00.000Z` |


### PR DESCRIPTION
Noticed an issue with the documentation where the date and time modifiers were switched up, went ahead and fixed it.