### PR TITLE
fix: update pnpm in docs to v11

### DIFF
--- a/content/docs/(main)/contributing.mdx
+++ b/content/docs/(main)/contributing.mdx
@@ -34,7 +34,7 @@ Here's how to setup Zipline for development
 ### Prerequisites
 
 - [nodejs@24](https://nodejs.org/)
-- [pnpm@10.10.0](https://pnpm.io/installation)
+- [pnpm@11](https://pnpm.io/installation)
 - [ffmpeg](https://ffmpeg.org/download.html) (for generating thumbnails, optional)
 - a [postgresql](https://postgresql.org) server
 

--- a/content/docs/(main)/get-started/source.mdx
+++ b/content/docs/(main)/get-started/source.mdx
@@ -8,7 +8,7 @@ Building Zipline from source is not recommended for most users, as it requires s
 ## Install Prerequisites [step]
 
 - [nodejs@22](https://nodejs.org/)
-- [pnpm@10.10.0](https://pnpm.io/installation)
+- [pnpm@11](https://pnpm.io/installation)
 - [ffmpeg](https://ffmpeg.org/download.html) (for generating thumbnails, optional)
 
 <Callout type='note'>


### PR DESCRIPTION
Zipline has been recently updated to pnpm v11 so documentation also needs to be updated